### PR TITLE
Add key as allowed param

### DIFF
--- a/lib/google_timezone/base.rb
+++ b/lib/google_timezone/base.rb
@@ -3,7 +3,7 @@ require 'open-uri'
 
 module GoogleTimezone
   class Base
-    @allowed_params = [:language, :sensor, :timestamp, :client, :signature]
+    @allowed_params = [:language, :sensor, :timestamp, :client, :signature, :key]
 
     def initialize(*args)
       @lat, @lon = if args.first.is_a? Array


### PR DESCRIPTION
Google's timezone API documentation indicates that all apps should use
an API key for requests.
https://developers.google.com/maps/documentation/timezone/#api_key

The "key" parameter was not in the list of allowed_params and would be
rejected. This change simply adds :key to the list of allowed_params.
