### PR TITLE
Provide a way to stub remote calls in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Also there is `GoogleTimezone::Result#success?` method. It returns true if respo
 
 The bang version `fetch!` raises an `GoogleTimezone::Error` exception with error message if response from Google wasn't success.
 
+## Usage in tests/specs
+
+During tests, you probably don't want to make remote calls. To achieve this, you should set a default stub in your test/spec helper file, e.g.:
+
+    # spec/support/google_timezone.rb
+    GoogleTimezone.set_default_stub(
+      'dstOffset' => 3600,
+      'rawOffset' => -10800,
+      'status' => 'OK',
+      'timeZoneId' => 'America/Sao_Paulo',
+      'timeZoneName' => 'Brasilia Summer Time'
+    )
 
 ## Contributing
 

--- a/lib/google_timezone.rb
+++ b/lib/google_timezone.rb
@@ -11,5 +11,9 @@ module GoogleTimezone
     def fetch!(*args)
       Base.new(*args).fetch!
     end
+
+    def set_default_stub(default_stub)
+      Base.default_stub = default_stub
+    end
   end
 end

--- a/lib/google_timezone/base.rb
+++ b/lib/google_timezone/base.rb
@@ -8,6 +8,10 @@ module GoogleTimezone
   class Base
     ALLOWED_PARAMS = [:language, :sensor, :timestamp, :client, :signature, :key]
 
+    class << self
+      attr_accessor :default_stub
+    end
+
     def initialize(*args)
       @lat, @lon = if args.first.is_a? Array
                      args.first
@@ -47,7 +51,7 @@ module GoogleTimezone
     end
 
     def get_result(params)
-      open(url(params)) { |r| JSON.parse(r.read) }
+      self.class.default_stub || open(url(params)) { |r| JSON.parse(r.read) }
     end
   end
 end

--- a/spec/google_timezone_spec.rb
+++ b/spec/google_timezone_spec.rb
@@ -1,15 +1,19 @@
 require 'google_timezone'
 
 describe GoogleTimezone do
-  let(:raw_result) { {} }
+  def self.stub_remote_calls!
+    let(:raw_result) { {} }
 
-  before do
-    allow_any_instance_of(GoogleTimezone::Base).to(
-      receive(:get_result).and_return(raw_result)
-    )
+    before do
+      allow_any_instance_of(GoogleTimezone::Base).to(
+        receive(:get_result).and_return(raw_result)
+      )
+    end
   end
 
   describe '.fetch' do
+    stub_remote_calls!
+
     context 'without any optional parameters' do
       it 'should accept separate lat/long paramenters' do
         g = GoogleTimezone.fetch(0, 0)
@@ -44,6 +48,8 @@ describe GoogleTimezone do
   end
 
   describe '.fetch!' do
+    stub_remote_calls!
+
     describe 'if result is not successful' do
       it 'should raise an error' do
         expect { GoogleTimezone.fetch!(0, 0) }.to raise_error(GoogleTimezone::Error)
@@ -57,6 +63,22 @@ describe GoogleTimezone do
         g = GoogleTimezone.fetch!(0, 0)
         expect(g).to be_an_instance_of(GoogleTimezone::Result)
       end
+    end
+  end
+
+  describe '.set_default_stub' do
+    after { GoogleTimezone.set_default_stub(nil) }
+
+    it 'does not make a remote call' do
+      GoogleTimezone.set_default_stub({})
+      expect_any_instance_of(GoogleTimezone::Base).not_to receive(:open)
+      GoogleTimezone.fetch(0, 0)
+    end
+
+    it 'returns the configured stub' do
+      GoogleTimezone.set_default_stub('timeZoneId' => 'Europe/Berlin')
+      g = GoogleTimezone.fetch(0, 0)
+      expect(g.time_zone_id).to eq('Europe/Berlin')
     end
   end
 end

--- a/spec/google_timezone_spec.rb
+++ b/spec/google_timezone_spec.rb
@@ -1,23 +1,16 @@
 require 'google_timezone'
 
 describe GoogleTimezone do
+  let(:raw_result) { {} }
+
+  before do
+    allow_any_instance_of(GoogleTimezone::Base).to(
+      receive(:get_result).and_return(raw_result)
+    )
+  end
+
   describe '.fetch' do
     context 'without any optional parameters' do
-      let(:base_instance) { spy }
-      let(:result) { GoogleTimezone::Result.new({}) }
-
-      before do
-        allow_any_instance_of(GoogleTimezone::Base).to(
-          receive(:new).with(any_args)
-                       .and_return(base_instance)
-        )
-
-        allow(base_instance).to(
-          receive(:fetch).with(no_args)
-                         .and_return(result)
-        )
-      end
-
       it 'should accept separate lat/long paramenters' do
         g = GoogleTimezone.fetch(0, 0)
         expect(g).to be_an_instance_of(GoogleTimezone::Result)
@@ -30,25 +23,11 @@ describe GoogleTimezone do
     end
 
     context 'with optional parameters' do
-      let(:base_instance) { spy }
-      let(:result) { GoogleTimezone::Result.new(0) }
       let(:valid_params)   { { timestamp: 1331161200,
                                key: 'A24br8v2w' } }
       let(:invalid_params) { { timestamp: 1331161200,
                                key: 'A24br8v2w',
                                unallowed_param: true } }
-
-      before(:each) do
-        allow_any_instance_of(GoogleTimezone::Base).to(
-          receive(:new).with(0, 0, valid_params)
-                       .and_return(base_instance)
-        )
-
-        allow(base_instance).to(
-          receive(:fetch).with(no_args)
-                         .and_return(result)
-        )
-      end
 
       it 'should pass allowed parameters on to the query' do
         g = GoogleTimezone.fetch(0, 0, valid_params)
@@ -56,6 +35,8 @@ describe GoogleTimezone do
       end
 
       it 'should reject unallowed parameters' do
+        a_hash_excluding = ->(*keys) { satisfy {|actual| (keys & actual.keys).empty? } }
+        expect_any_instance_of(GoogleTimezone::Base).to receive(:get_result).with(a_hash_excluding[:unallowed_param])
         g = GoogleTimezone.fetch(0, 0, invalid_params)
         expect(g).to be_an_instance_of(GoogleTimezone::Result)
       end
@@ -64,19 +45,17 @@ describe GoogleTimezone do
 
   describe '.fetch!' do
     describe 'if result is not successful' do
-      let(:result) { GoogleTimezone::Result.new({}) }
-      let(:error)  { GoogleTimezone::Error }
-
-      before { allow(result).to receive(:success?).and_return(false) }
-      before { allow(result).to receive(:result).and_return('error message') }
-      before {
-        allow_any_instance_of(GoogleTimezone::Base).to(
-          receive(:fetch).and_return(result)
-        )
-      }
-
       it 'should raise an error' do
-        expect { GoogleTimezone.fetch!(0,0) }.to raise_error(error)
+        expect { GoogleTimezone.fetch!(0, 0) }.to raise_error(GoogleTimezone::Error)
+      end
+    end
+
+    describe 'if result is successul' do
+      let(:raw_result) { {'status' => 'OK'} }
+
+      it 'should return a result' do
+        g = GoogleTimezone.fetch!(0, 0)
+        expect(g).to be_an_instance_of(GoogleTimezone::Result)
       end
     end
   end


### PR DESCRIPTION
This PR introduces `GoogleTimezone.set_default_stub`, which can be very handy in tests/specs.