### PR TITLE
Fix Ruby 2.7 warning about using Kernel#open

### DIFF
--- a/lib/google_timezone/base.rb
+++ b/lib/google_timezone/base.rb
@@ -51,7 +51,7 @@ module GoogleTimezone
     end
 
     def get_result(params)
-      self.class.default_stub || open(url(params)) { |r| JSON.parse(r.read) }
+      self.class.default_stub || URI.open(url(params)) { |r| JSON.parse(r.read) }
     end
   end
 end


### PR DESCRIPTION
Using Ruby 2.7, the gem displays this warning message:

```
/[...]/vendor/bundle/ruby/2.7.0/gems/google_timezone-0.0.5/lib/google_timezone/base.rb:54: 
warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```

I've fixed this by using `URI.open`